### PR TITLE
Fix large p2p http bodies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
         <dependency>
             <groupId>com.github.peergos</groupId>
             <artifactId>jvm-libp2p</artifactId>
-            <version>0.13.0</version>
+            <version>0.14.0</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/src/test/java/org/peergos/HttpProxyTest.java
+++ b/src/test/java/org/peergos/HttpProxyTest.java
@@ -33,7 +33,7 @@ public class HttpProxyTest {
         node2.start().join();
 
         // start local server with fixed HTTP response
-        byte[] httpReply = new byte[577*1024];
+        byte[] httpReply = new byte[1024*1024];
         new Random(42).nextBytes(httpReply);
         HttpServer localhostServer = HttpServer.create(proxyTarget, 20);
         localhostServer.createContext("/", ex -> {


### PR DESCRIPTION
This includes a fixed  jvm-libp2p which fixes writing arrays larger than the yamux window size.