### PR TITLE
Optimise legacy bitswap usage

### DIFF
--- a/src/main/java/org/peergos/BitswapBlockService.java
+++ b/src/main/java/org/peergos/BitswapBlockService.java
@@ -2,10 +2,12 @@ package org.peergos;
 
 import io.ipfs.cid.*;
 import io.libp2p.core.*;
+import io.libp2p.core.Stream;
 import org.peergos.protocol.bitswap.*;
 import org.peergos.protocol.dht.*;
 
 import java.util.*;
+import java.util.concurrent.*;
 import java.util.stream.*;
 
 public class BitswapBlockService implements BlockService {
@@ -23,10 +25,30 @@ public class BitswapBlockService implements BlockService {
     @Override
     public List<HashedBlock> get(List<Want> hashes, Set<PeerId> peers, boolean addToBlockstore) {
         if (peers.isEmpty()) {
+            // if peers are not provided try connected peers and then fallback to finding peers from DHT
+            Set<PeerId> connected = us.getStreams().stream()
+                    .map(Stream::remotePeerId)
+                    .collect(Collectors.toSet());
+            Set<HashedBlock> fromConnected = bitswap.get(hashes, us, connected, addToBlockstore)
+                    .stream()
+                    .map(f -> f.orTimeout(10, TimeUnit.SECONDS).join())
+                    .collect(Collectors.toSet());
+            if (fromConnected.size() == hashes.size())
+                return new ArrayList<>(fromConnected);
+
+            Set<Cid> done = fromConnected.stream().map(b -> b.hash).collect(Collectors.toSet());
+            List<Want> remaining = hashes.stream()
+                    .filter(w -> !done.contains(w.cid))
+                    .collect(Collectors.toList());
             List<PeerAddresses> providers = dht.findProviders(hashes.get(0).cid, us, 5).join();
             peers = providers.stream()
                     .map(p -> PeerId.fromBase58(p.peerId.toBase58()))
                     .collect(Collectors.toSet());
+            return java.util.stream.Stream.concat(bitswap.get(remaining, us, peers, addToBlockstore)
+                                    .stream()
+                                    .map(f -> f.join()),
+                            fromConnected.stream())
+                    .collect(Collectors.toList());
         }
         return bitswap.get(hashes, us, peers, addToBlockstore)
                 .stream()


### PR DESCRIPTION
In the case when no peers are provided, make bitswap try connected peers before resorting to DHT findProviders