### PR TITLE
Improve bitswap peer selection

### DIFF
--- a/src/main/java/org/peergos/BitswapBlockService.java
+++ b/src/main/java/org/peergos/BitswapBlockService.java
@@ -26,9 +26,7 @@ public class BitswapBlockService implements BlockService {
     public List<HashedBlock> get(List<Want> hashes, Set<PeerId> peers, boolean addToBlockstore) {
         if (peers.isEmpty()) {
             // if peers are not provided try connected peers and then fallback to finding peers from DHT
-            Set<PeerId> connected = us.getStreams().stream()
-                    .map(Stream::remotePeerId)
-                    .collect(Collectors.toSet());
+            Set<PeerId> connected = bitswap.getBroadcastAudience();
             Set<HashedBlock> fromConnected = bitswap.get(hashes, us, connected, addToBlockstore)
                     .stream()
                     .flatMap(f -> {

--- a/src/main/java/org/peergos/HostBuilder.java
+++ b/src/main/java/org/peergos/HostBuilder.java
@@ -148,7 +148,7 @@ public class HostBuilder {
             b.getIdentity().setFactory(() -> privKey);
             b.getTransports().add(TcpTransport::new);
             b.getSecureChannels().add(NoiseXXSecureChannel::new);
-            b.getSecureChannels().add(TlsSecureChannel::new);
+//            b.getSecureChannels().add(TlsSecureChannel::new);
 
             b.getMuxers().addAll(muxers);
             RamAddressBook addrs = new RamAddressBook();
@@ -160,6 +160,8 @@ public class HostBuilder {
                 b.getProtocols().add(protocol);
                 if (protocol instanceof AddressBookConsumer)
                     ((AddressBookConsumer) protocol).setAddressBook(addrs);
+                if (protocol instanceof ConnectionHandler)
+                    b.getConnectionHandlers().add((ConnectionHandler) protocol);
             }
 
             // Send an identify req on all new incoming connections


### PR DESCRIPTION
Make sure outgoing connections from any protocol are candidates for bitswap broadcast

Make bitswap tolerate errors connecting to some peers

disable TLS by default until it is less noisy (pun intended)