### PR TITLE
Fix addresses we announce via Identify with wildcards

### DIFF
--- a/src/main/java/org/peergos/protocol/IdentifyBuilder.java
+++ b/src/main/java/org/peergos/protocol/IdentifyBuilder.java
@@ -3,11 +3,15 @@ package org.peergos.protocol;
 import identify.pb.*;
 import io.libp2p.core.*;
 import io.libp2p.core.multiformats.*;
+import io.libp2p.core.multiformats.Protocol;
 import io.libp2p.core.multistream.*;
 import io.libp2p.etc.types.*;
 import io.libp2p.protocol.*;
 
+import java.net.*;
+import java.util.*;
 import java.util.stream.*;
+import java.util.stream.Stream;
 
 public class IdentifyBuilder {
 
@@ -17,6 +21,7 @@ public class IdentifyBuilder {
                 .setAgentVersion("nabu/v0.1.0")
                 .setPublicKey(ByteArrayExtKt.toProtobuf(node.getPrivKey().publicKey().bytes()))
                 .addAllListenAddrs(node.listenAddresses().stream()
+                        .flatMap(a -> expandWildcardAddresses(a).stream())
                         .map(Multiaddr::serialize)
                         .map(ByteArrayExtKt::toProtobuf)
                         .collect(Collectors.toList()));
@@ -26,5 +31,56 @@ public class IdentifyBuilder {
         }
         Identify identify = new Identify(identifyBuilder.build());
         node.addProtocolHandler(identify);
+    }
+
+    /* /ip6/::/tcp/4001 should expand to the following for example:
+    "/ip6/0:0:0:0:0:0:0:1/udp/4001/quic"
+    "/ip4/50.116.48.246/tcp/4001"
+    "/ip4/127.0.0.1/tcp/4001"
+    "/ip6/2600:3c03:0:0:f03c:92ff:fee7:bc1c/tcp/4001"
+    "/ip6/0:0:0:0:0:0:0:1/tcp/4001"
+    "/ip4/50.116.48.246/udp/4001/quic"
+    "/ip4/127.0.0.1/udp/4001/quic"
+    "/ip6/2600:3c03:0:0:f03c:92ff:fee7:bc1c/udp/4001/quic"
+     */
+    public static List<Multiaddr> expandWildcardAddresses(Multiaddr addr) {
+        // Do not include /p2p or /ipfs components which are superfluous here
+        if (! isWildcard(addr))
+            return List.of(new Multiaddr(addr.getComponents()
+                    .stream()
+                    .filter(c -> c.getProtocol() != Protocol.P2P
+                            && c.getProtocol() != Protocol.IPFS)
+                    .collect(Collectors.toList())));
+        if (addr.has(Protocol.IP4))
+            return listNetworkAddresses(false, addr);
+        if (addr.has(Protocol.IP6)) // include IP4
+            return listNetworkAddresses(true, addr);
+        return Collections.emptyList();
+    }
+
+    public static List<Multiaddr> listNetworkAddresses(boolean includeIp6, Multiaddr addr) {
+        try {
+            return NetworkInterface.networkInterfaces()
+                    .flatMap(net -> net.getInterfaceAddresses().stream()
+                            .map(InterfaceAddress::getAddress)
+                            .filter(ip -> includeIp6 || ip instanceof Inet4Address))
+                    .map(ip -> new Multiaddr(Stream.concat(Stream.of(new MultiaddrComponent(ip instanceof Inet4Address ?
+                                            Protocol.IP4 :
+                                            Protocol.IP6, ip.getAddress())),
+                                    addr.getComponents().stream()
+                                            .filter(c -> c.getProtocol() != Protocol.IP4
+                                                    && c.getProtocol() != Protocol.IP6
+                                                    && c.getProtocol() != Protocol.P2P
+                                                    && c.getProtocol() != Protocol.IPFS))
+                            .collect(Collectors.toList())))
+                    .collect(Collectors.toList());
+        } catch (SocketException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static boolean isWildcard(Multiaddr addr) {
+        String s = addr.toString();
+        return s.contains("/::/") || s.contains("/0:0:0:0/");
     }
 }

--- a/src/test/java/org/peergos/EmbeddedIpfsTest.java
+++ b/src/test/java/org/peergos/EmbeddedIpfsTest.java
@@ -1,9 +1,12 @@
 package org.peergos;
 
+import identify.pb.*;
 import io.ipfs.cid.*;
 import io.ipfs.multiaddr.*;
 import io.libp2p.core.*;
 import io.libp2p.core.crypto.*;
+import io.libp2p.core.multiformats.*;
+import io.libp2p.protocol.*;
 import org.junit.*;
 import org.peergos.blockstore.*;
 import org.peergos.config.*;
@@ -17,12 +20,12 @@ public class EmbeddedIpfsTest {
 
     @Test
     public void largeBlock() throws Exception {
-        EmbeddedIpfs node1 = build(Collections.emptyList());
+        EmbeddedIpfs node1 = build(Collections.emptyList(), List.of(new MultiAddress("/ip4/127.0.0.1/tcp/" + TestPorts.getPort())));
         node1.start();
         EmbeddedIpfs node2 = build(node1.node.listenAddresses()
                 .stream()
                 .map(a -> new MultiAddress(a.toString()))
-                .collect(Collectors.toList()));
+                .collect(Collectors.toList()), List.of(new MultiAddress("/ip4/127.0.0.1/tcp/" + TestPorts.getPort())));
         node2.start();
 
         Cid block = node2.blockstore.put(new byte[1024 * 1024], Cid.Codec.Raw).join();
@@ -36,9 +39,26 @@ public class EmbeddedIpfsTest {
         node2.stop();
     }
 
-    public static EmbeddedIpfs build(List<MultiAddress> bootstrap) {
-        int swarm = TestPorts.getPort();
-        List<MultiAddress> swarmAddresses = List.of(new MultiAddress("/ip4/127.0.0.1/tcp/" + swarm));
+    @Test
+    public void wildcardListenerAddressesGetExpanded() {
+        int node1Port = TestPorts.getPort();
+        EmbeddedIpfs node1 = build(Collections.emptyList(), List.of(new MultiAddress("/ip6/::/tcp/" + node1Port)));
+        node1.start();
+
+        EmbeddedIpfs node2 = build(node1.node.listenAddresses()
+                .stream()
+                .map(a -> new MultiAddress(a.toString()))
+                .collect(Collectors.toList()), List.of(new MultiAddress("/ip4/127.0.0.1/tcp/" + TestPorts.getPort())));
+        node2.start();
+        Multiaddr node1Addr = new Multiaddr("/ip4/127.0.0.1/tcp/" + node1Port + "/p2p/" + node1.node.getPeerId());
+        IdentifyOuterClass.Identify id = new Identify().dial(node2.node, node1Addr).getController().join().id().join();
+        List<MultiAddress> listening = id.getListenAddrsList().stream().map(b -> new MultiAddress(b.toByteArray())).collect(Collectors.toList());
+        Assert.assertTrue(listening.stream().anyMatch(a -> a.toString().contains("/ip4/127.0.0.1")));
+        Assert.assertTrue(listening.stream().noneMatch(a -> a.toString().contains("/p2p/")));
+        Assert.assertTrue(listening.stream().noneMatch(a -> a.toString().contains("/ipfs/")));
+    }
+
+    public static EmbeddedIpfs build(List<MultiAddress> bootstrap, List<MultiAddress> swarmAddresses) {
         BlockRequestAuthoriser blockRequestAuthoriser = (c, b, p, a) -> CompletableFuture.completedFuture(true);
         HostBuilder builder = new HostBuilder().generateIdentity();
         PrivKey privKey = builder.getPrivateKey();


### PR DESCRIPTION
If we are listening on a wildcard address we need to expand it, and find all the matching interfaces and their ip addresses.

Add a test to verify this to EmbeddedIpfsTest