### PR TITLE
Don't retrieve block for authing bitswap requests

### DIFF
--- a/src/main/java/org/peergos/BlockRequestAuthoriser.java
+++ b/src/main/java/org/peergos/BlockRequestAuthoriser.java
@@ -6,5 +6,5 @@ import java.util.concurrent.*;
 
 public interface BlockRequestAuthoriser {
 
-    CompletableFuture<Boolean> allowRead(Cid block, byte[] blockData, Cid sourceNodeId, String auth);
+    CompletableFuture<Boolean> allowRead(Cid block, Cid sourceNodeId, String auth);
 }

--- a/src/main/java/org/peergos/Nabu.java
+++ b/src/main/java/org/peergos/Nabu.java
@@ -47,7 +47,7 @@ public class Nabu {
             AggregatedMetrics.startExporter(config.metrics.address, config.metrics.port);
         }
         LOG.info("Starting Nabu version: " + APIHandler.CURRENT_VERSION);
-        BlockRequestAuthoriser authoriser = (c, b, p, a) -> CompletableFuture.completedFuture(true);
+        BlockRequestAuthoriser authoriser = (c, p, a) -> CompletableFuture.completedFuture(true);
 
         Path datastorePath = ipfsPath.resolve("datastore").resolve("h2.datastore");
         DatabaseRecordStore records = new DatabaseRecordStore(datastorePath.toAbsolutePath().toString());

--- a/src/test/java/org/peergos/BitswapMirrorTest.java
+++ b/src/test/java/org/peergos/BitswapMirrorTest.java
@@ -23,7 +23,7 @@ public class BitswapMirrorTest {
     //@Ignore // Local testing only for now - run this prior: ./ipfs pin add zdpuAwfJrGYtiGFDcSV3rDpaUrqCtQZRxMjdC6Eq9PNqLqTGg
     public void mirrorTree() throws IOException {
         HostBuilder builder1 = HostBuilder.create(TestPorts.getPort(),
-                new RamProviderStore(1000), new RamRecordStore(), new RamBlockstore(), (c, b, p, a) -> CompletableFuture.completedFuture(true));
+                new RamProviderStore(1000), new RamRecordStore(), new RamBlockstore(), (c, p, a) -> CompletableFuture.completedFuture(true));
         Host node1 = builder1.build();
         node1.start().join();
         IdentifyBuilder.addIdentifyProtocol(node1);

--- a/src/test/java/org/peergos/BitswapTest.java
+++ b/src/test/java/org/peergos/BitswapTest.java
@@ -20,11 +20,11 @@ public class BitswapTest {
     @Test
     public void getBlock() {
         HostBuilder builder1 = HostBuilder.create(TestPorts.getPort(),
-                new RamProviderStore(1000), new RamRecordStore(), new RamBlockstore(), (c, b, p, a) -> CompletableFuture.completedFuture(true));
+                new RamProviderStore(1000), new RamRecordStore(), new RamBlockstore(), (c, p, a) -> CompletableFuture.completedFuture(true));
         Host node1 = builder1.build();
         RamBlockstore blockstore2 = new RamBlockstore();
         HostBuilder builder2 = HostBuilder.create(TestPorts.getPort(),
-                new RamProviderStore(1000), new RamRecordStore(), blockstore2, (c, b, p, a) -> CompletableFuture.completedFuture(true));
+                new RamProviderStore(1000), new RamRecordStore(), blockstore2, (c, p, a) -> CompletableFuture.completedFuture(true));
         Host node2 = builder2.build();
         node1.start().join();
         node2.start().join();
@@ -49,11 +49,11 @@ public class BitswapTest {
     @Test
     public void blockFlooder() {
         HostBuilder builder1 = HostBuilder.create(TestPorts.getPort(),
-                new RamProviderStore(1000), new RamRecordStore(), new RamBlockstore(), (c, b, p, a) -> CompletableFuture.completedFuture(true));
+                new RamProviderStore(1000), new RamRecordStore(), new RamBlockstore(), (c, p, a) -> CompletableFuture.completedFuture(true));
         Host flooder = builder1.build();
         RamBlockstore blockstore2 = new RamBlockstore();
         HostBuilder builder2 = HostBuilder.create(TestPorts.getPort(),
-                new RamProviderStore(1000), new RamRecordStore(), blockstore2, (c, b, p, a) -> CompletableFuture.completedFuture(true), true);
+                new RamProviderStore(1000), new RamRecordStore(), blockstore2, (c, p, a) -> CompletableFuture.completedFuture(true), true);
         Host node2 = builder2.build();
         flooder.start().join();
         node2.start().join();

--- a/src/test/java/org/peergos/BootstrapTest.java
+++ b/src/test/java/org/peergos/BootstrapTest.java
@@ -37,7 +37,7 @@ public class BootstrapTest {
     @Test
     public void bootstrap() {
         HostBuilder builder1 = HostBuilder.create(TestPorts.getPort(),
-                new RamProviderStore(1000), new RamRecordStore(), new RamBlockstore(), (c, b, p, a) -> CompletableFuture.completedFuture(true));
+                new RamProviderStore(1000), new RamRecordStore(), new RamBlockstore(), (c, p, a) -> CompletableFuture.completedFuture(true));
         Host node1 = builder1.build();
         node1.start().join();
         IdentifyBuilder.addIdentifyProtocol(node1);

--- a/src/test/java/org/peergos/EmbeddedIpfsTest.java
+++ b/src/test/java/org/peergos/EmbeddedIpfsTest.java
@@ -59,7 +59,7 @@ public class EmbeddedIpfsTest {
     }
 
     public static EmbeddedIpfs build(List<MultiAddress> bootstrap, List<MultiAddress> swarmAddresses) {
-        BlockRequestAuthoriser blockRequestAuthoriser = (c, b, p, a) -> CompletableFuture.completedFuture(true);
+        BlockRequestAuthoriser blockRequestAuthoriser = (c, p, a) -> CompletableFuture.completedFuture(true);
         HostBuilder builder = new HostBuilder().generateIdentity();
         PrivKey privKey = builder.getPrivateKey();
         PeerId peerId = builder.getPeerId();

--- a/src/test/java/org/peergos/FindPeerTest.java
+++ b/src/test/java/org/peergos/FindPeerTest.java
@@ -17,7 +17,7 @@ public class FindPeerTest {
     public void findLongRunningNode() {
         RamBlockstore blockstore1 = new RamBlockstore();
         HostBuilder builder1 = HostBuilder.create(TestPorts.getPort(),
-                new RamProviderStore(1000), new RamRecordStore(), blockstore1, (c, b, p, a) -> CompletableFuture.completedFuture(true));
+                new RamProviderStore(1000), new RamRecordStore(), blockstore1, (c, p, a) -> CompletableFuture.completedFuture(true));
         Host node1 = builder1.build();
         node1.start().join();
         IdentifyBuilder.addIdentifyProtocol(node1);

--- a/src/test/java/org/peergos/FindProviderTest.java
+++ b/src/test/java/org/peergos/FindProviderTest.java
@@ -20,7 +20,7 @@ public class FindProviderTest {
     public void findBlockProvider() {
         RamBlockstore blockstore = new RamBlockstore();
         HostBuilder builder1 = HostBuilder.create(TestPorts.getPort(),
-                new RamProviderStore(1000), new RamRecordStore(), blockstore, (c, b, p, a) -> CompletableFuture.completedFuture(true));
+                new RamProviderStore(1000), new RamRecordStore(), blockstore, (c, p, a) -> CompletableFuture.completedFuture(true));
         Host node1 = builder1.build();
         node1.start().join();
 

--- a/src/test/java/org/peergos/HandlerTest.java
+++ b/src/test/java/org/peergos/HandlerTest.java
@@ -82,7 +82,7 @@ public class HandlerTest {
     public void findBlockProviderTest() throws IOException {
         RamBlockstore blockstore = new RamBlockstore();
         HostBuilder builder1 = HostBuilder.create(10000 + new Random().nextInt(50000),
-                new RamProviderStore(1000), new RamRecordStore(), blockstore, (c, b, p, a) -> CompletableFuture.completedFuture(true));
+                new RamProviderStore(1000), new RamRecordStore(), blockstore, (c, p, a) -> CompletableFuture.completedFuture(true));
         Host node1 = builder1.build();
         node1.start().join();
         HttpServer apiServer = null;

--- a/src/test/java/org/peergos/HttpProxyTest.java
+++ b/src/test/java/org/peergos/HttpProxyTest.java
@@ -34,12 +34,12 @@ public class HttpProxyTest {
     public void p2pProxyRequest() throws IOException {
         InetSocketAddress unusedProxyTarget = new InetSocketAddress("127.0.0.1", 7000);
         HostBuilder builder1 = HostBuilder.create(TestPorts.getPort(),
-                new RamProviderStore(1000), new RamRecordStore(), new RamBlockstore(), (c, b, p, a) -> CompletableFuture.completedFuture(true))
+                new RamProviderStore(1000), new RamRecordStore(), new RamBlockstore(), (c, p, a) -> CompletableFuture.completedFuture(true))
                 .addProtocol(new HttpProtocol.Binding(unusedProxyTarget));
         Host node1 = builder1.build();
         InetSocketAddress proxyTarget = new InetSocketAddress("127.0.0.1", TestPorts.getPort());
         HostBuilder builder2 = HostBuilder.create(TestPorts.getPort(),
-                        new RamProviderStore(1000), new RamRecordStore(), new RamBlockstore(), (c, b, p, a) -> CompletableFuture.completedFuture(true))
+                        new RamProviderStore(1000), new RamRecordStore(), new RamBlockstore(), (c, p, a) -> CompletableFuture.completedFuture(true))
                 .addProtocol(new HttpProtocol.Binding(proxyTarget));
         Host node2 = builder2.build();
         node1.start().join();
@@ -95,7 +95,7 @@ public class HttpProxyTest {
     public void p2pProxyClientTest() throws Exception {
         InetSocketAddress unusedProxyTarget = new InetSocketAddress("127.0.0.1", 7000);
         HostBuilder builder1 = HostBuilder.create(TestPorts.getPort(),
-                        new RamProviderStore(1000), new RamRecordStore(), new RamBlockstore(), (c, b, p, a) -> CompletableFuture.completedFuture(true))
+                        new RamProviderStore(1000), new RamRecordStore(), new RamBlockstore(), (c, p, a) -> CompletableFuture.completedFuture(true))
                 .addProtocol(new HttpProtocol.Binding(unusedProxyTarget));
         Host node1 = builder1.build();
         node1.start().join();

--- a/src/test/java/org/peergos/IpnsTest.java
+++ b/src/test/java/org/peergos/IpnsTest.java
@@ -24,7 +24,7 @@ public class IpnsTest {
     public void publishIPNSRecordToKubo() throws IOException {
         RamBlockstore blockstore1 = new RamBlockstore();
         HostBuilder builder1 = HostBuilder.create(TestPorts.getPort(),
-                new RamProviderStore(1000), new RamRecordStore(), blockstore1, (c, b, p, a) -> CompletableFuture.completedFuture(true));
+                new RamProviderStore(1000), new RamRecordStore(), blockstore1, (c, p, a) -> CompletableFuture.completedFuture(true));
         Host node1 = builder1.build();
         node1.start().join();
         IdentifyBuilder.addIdentifyProtocol(node1);
@@ -70,7 +70,7 @@ public class IpnsTest {
     public void retrieveKuboPublishedIPNS() throws IOException {
         RamBlockstore blockstore1 = new RamBlockstore();
         HostBuilder builder1 = HostBuilder.create(10000 + new Random().nextInt(50000),
-                new RamProviderStore(1000), new RamRecordStore(), blockstore1, (c, b, p, a) -> CompletableFuture.completedFuture(true));
+                new RamProviderStore(1000), new RamRecordStore(), blockstore1, (c, p, a) -> CompletableFuture.completedFuture(true));
         Host node1 = builder1.build();
         node1.start().join();
         IdentifyBuilder.addIdentifyProtocol(node1);

--- a/src/test/java/org/peergos/KademliaTest.java
+++ b/src/test/java/org/peergos/KademliaTest.java
@@ -20,13 +20,13 @@ public class KademliaTest {
     public void findOtherNode() throws Exception {
         RamBlockstore blockstore1 = new RamBlockstore();
         HostBuilder builder1 = HostBuilder.create(TestPorts.getPort(),
-                new RamProviderStore(1000), new RamRecordStore(), blockstore1, (c, b, p, a) -> CompletableFuture.completedFuture(true));
+                new RamProviderStore(1000), new RamRecordStore(), blockstore1, (c, p, a) -> CompletableFuture.completedFuture(true));
         Host node1 = builder1.build();
         node1.start().join();
         IdentifyBuilder.addIdentifyProtocol(node1);
 
         HostBuilder builder2 = HostBuilder.create(TestPorts.getPort(),
-                new RamProviderStore(1000), new RamRecordStore(), new RamBlockstore(), (c, b, p, a) -> CompletableFuture.completedFuture(true));
+                new RamProviderStore(1000), new RamRecordStore(), new RamBlockstore(), (c, p, a) -> CompletableFuture.completedFuture(true));
         Host node2 = builder2.build();
         node2.start().join();
         IdentifyBuilder.addIdentifyProtocol(node2);
@@ -61,13 +61,13 @@ public class KademliaTest {
     public void ipnsBenchmark() throws Exception {
         RamBlockstore blockstore1 = new RamBlockstore();
         HostBuilder builder1 = HostBuilder.create(TestPorts.getPort(),
-                new RamProviderStore(1000), new RamRecordStore(), blockstore1, (c, b, p, a) -> CompletableFuture.completedFuture(true));
+                new RamProviderStore(1000), new RamRecordStore(), blockstore1, (c, p, a) -> CompletableFuture.completedFuture(true));
         Host node1 = builder1.build();
         node1.start().join();
         IdentifyBuilder.addIdentifyProtocol(node1);
 
         HostBuilder builder2 = HostBuilder.create(TestPorts.getPort(),
-                new RamProviderStore(1000), new RamRecordStore(), new RamBlockstore(), (c, b, p, a) -> CompletableFuture.completedFuture(true));
+                new RamProviderStore(1000), new RamRecordStore(), new RamBlockstore(), (c, p, a) -> CompletableFuture.completedFuture(true));
         Host node2 = builder2.build();
         node2.start().join();
         IdentifyBuilder.addIdentifyProtocol(node2);

--- a/src/test/java/org/peergos/KuboFindProviderTest.java
+++ b/src/test/java/org/peergos/KuboFindProviderTest.java
@@ -20,7 +20,7 @@ public class KuboFindProviderTest {
     @Test
     public void findProviderOverYamux() throws IOException {
         HostBuilder builder1 = HostBuilder.create(TestPorts.getPort(), new RamProviderStore(1000),
-                        new RamRecordStore(), new RamBlockstore(), (c, b, p, a) -> CompletableFuture.completedFuture(true))
+                        new RamRecordStore(), new RamBlockstore(), (c, p, a) -> CompletableFuture.completedFuture(true))
                 .addMuxers(List.of(StreamMuxerProtocol.getYamux()));
         Host node1 = builder1.build();
         node1.start().join();

--- a/src/test/java/org/peergos/KuboPingTest.java
+++ b/src/test/java/org/peergos/KuboPingTest.java
@@ -22,7 +22,7 @@ public class KuboPingTest {
         Host node1 = new HostBuilder()
                 .generateIdentity()
                 .listen(List.of(new MultiAddress("/ip4/0.0.0.0/tcp/" + TestPorts.getPort())))
-                .addProtocols(List.of(new Ping(), new Bitswap(new BitswapEngine(new RamBlockstore(), (c, b, p, a) -> CompletableFuture.completedFuture(true), Bitswap.MAX_MESSAGE_SIZE))))
+                .addProtocols(List.of(new Ping(), new Bitswap(new BitswapEngine(new RamBlockstore(), (c, p, a) -> CompletableFuture.completedFuture(true), Bitswap.MAX_MESSAGE_SIZE))))
                 .addMuxers(List.of(StreamMuxerProtocol.getYamux()))
                 .build();
         node1.start().join();

--- a/src/test/java/org/peergos/KuboTest.java
+++ b/src/test/java/org/peergos/KuboTest.java
@@ -18,7 +18,7 @@ public class KuboTest {
 
     @Test
     public void getBlock() throws IOException {
-        Bitswap bitswap1 = new Bitswap(new BitswapEngine(new RamBlockstore(), (c, b, p, a) -> CompletableFuture.completedFuture(true), Bitswap.MAX_MESSAGE_SIZE));
+        Bitswap bitswap1 = new Bitswap(new BitswapEngine(new RamBlockstore(), (c, p, a) -> CompletableFuture.completedFuture(true), Bitswap.MAX_MESSAGE_SIZE));
         Host node1 = HostBuilder.build(TestPorts.getPort(), List.of(bitswap1));
         node1.start().join();
         IdentifyBuilder.addIdentifyProtocol(node1);

--- a/src/test/java/org/peergos/P2pHttpChatTest.java
+++ b/src/test/java/org/peergos/P2pHttpChatTest.java
@@ -25,7 +25,7 @@ public class P2pHttpChatTest {
             h.accept(replyOk.retain());
         });
         HostBuilder builder1 = HostBuilder.create(TestPorts.getPort(),
-                new RamProviderStore(1000), new RamRecordStore(), new RamBlockstore(), (c, b, p, a) -> CompletableFuture.completedFuture(true))
+                new RamProviderStore(1000), new RamRecordStore(), new RamBlockstore(), (c, p, a) -> CompletableFuture.completedFuture(true))
                 .addProtocol(node1Http);
         Host node1 = builder1.build();
         HttpProtocol.Binding node2Http = new HttpProtocol.Binding((s, req, h) -> {
@@ -34,7 +34,7 @@ public class P2pHttpChatTest {
             h.accept(replyOk.retain());
         });
         HostBuilder builder2 = HostBuilder.create(TestPorts.getPort(),
-                        new RamProviderStore(1000), new RamRecordStore(), new RamBlockstore(), (c, b, p, a) -> CompletableFuture.completedFuture(true))
+                        new RamProviderStore(1000), new RamRecordStore(), new RamBlockstore(), (c, p, a) -> CompletableFuture.completedFuture(true))
                 .addProtocol(node2Http);
         Host node2 = builder2.build();
         node1.start().join();

--- a/src/test/java/org/peergos/P2pHttpTest.java
+++ b/src/test/java/org/peergos/P2pHttpTest.java
@@ -37,7 +37,7 @@ public class P2pHttpTest {
             h.accept(emptyReply.retain());
         });
         HostBuilder builder1 = HostBuilder.create(TestPorts.getPort(),
-                        new RamProviderStore(1000), new RamRecordStore(), new RamBlockstore(), (c, b, p, a) -> CompletableFuture.completedFuture(true));
+                        new RamProviderStore(1000), new RamRecordStore(), new RamBlockstore(), (c, p, a) -> CompletableFuture.completedFuture(true));
         builder1 = builder1.addProtocol(node1Http);
         Host node1 = builder1.build();
         node1.start().join();
@@ -73,7 +73,7 @@ public class P2pHttpTest {
             HttpProtocol.proxyRequest(req, new InetSocketAddress("127.0.0.1", localPort), h);
         });
         HostBuilder builder2 = HostBuilder.create(TestPorts.getPort(),
-                new RamProviderStore(1000), new RamRecordStore(), blockstore2, (c, b, p, a) -> CompletableFuture.completedFuture(true));
+                new RamProviderStore(1000), new RamRecordStore(), blockstore2, (c, p, a) -> CompletableFuture.completedFuture(true));
         builder2 = builder2.addProtocol(node2Http);
         Host node2 = builder2.build();
         node2.start().join();

--- a/src/test/java/org/peergos/PingTest.java
+++ b/src/test/java/org/peergos/PingTest.java
@@ -21,8 +21,8 @@ public class PingTest {
 
     @Test
     public void runPing() {
-        Host node1 = HostBuilder.build(TestPorts.getPort(), List.of(new Ping(), new Bitswap(new BitswapEngine(new RamBlockstore(), (c, b, p, a) -> CompletableFuture.completedFuture(true), Bitswap.MAX_MESSAGE_SIZE))));
-        Host node2 = HostBuilder.build(TestPorts.getPort(), List.of(new Ping(), new Bitswap(new BitswapEngine(new RamBlockstore(), (c, b, p, a) -> CompletableFuture.completedFuture(true), Bitswap.MAX_MESSAGE_SIZE))));
+        Host node1 = HostBuilder.build(TestPorts.getPort(), List.of(new Ping(), new Bitswap(new BitswapEngine(new RamBlockstore(), (c, p, a) -> CompletableFuture.completedFuture(true), Bitswap.MAX_MESSAGE_SIZE))));
+        Host node2 = HostBuilder.build(TestPorts.getPort(), List.of(new Ping(), new Bitswap(new BitswapEngine(new RamBlockstore(), (c, p, a) -> CompletableFuture.completedFuture(true), Bitswap.MAX_MESSAGE_SIZE))));
         node1.start().join();
         node2.start().join();
         try {
@@ -55,11 +55,11 @@ public class PingTest {
         PrivKey node1Keys = Ed25519Kt.generateEd25519KeyPair().getFirst();
         int node1Port = TestPorts.getPort();
         Host node1 = build(node1Keys, node1Port, List.of(new Ping(),
-                new Bitswap(new BitswapEngine(new RamBlockstore(), (c, b, p, a) -> CompletableFuture.completedFuture(true), Bitswap.MAX_MESSAGE_SIZE))));
+                new Bitswap(new BitswapEngine(new RamBlockstore(), (c, p, a) -> CompletableFuture.completedFuture(true), Bitswap.MAX_MESSAGE_SIZE))));
         PrivKey node2Keys = RsaKt.generateRsaKeyPair(2048).getFirst();
         int node2Port = TestPorts.getPort();
         Host node2 = build(node2Keys, node2Port, List.of(new Ping(),
-                new Bitswap(new BitswapEngine(new RamBlockstore(), (c, b, p, a) -> CompletableFuture.completedFuture(true), Bitswap.MAX_MESSAGE_SIZE))));
+                new Bitswap(new BitswapEngine(new RamBlockstore(), (c, p, a) -> CompletableFuture.completedFuture(true), Bitswap.MAX_MESSAGE_SIZE))));
         node1.start().join();
         node2.start().join();
         IdentifyBuilder.addIdentifyProtocol(node1);
@@ -84,8 +84,8 @@ public class PingTest {
 
     @Test
     public void replyIdentifyOnNewDial() {
-        Host node1 = HostBuilder.build(TestPorts.getPort(), List.of(new Ping(), new Bitswap(new BitswapEngine(new RamBlockstore(), (c, b, p, a) -> CompletableFuture.completedFuture(true), Bitswap.MAX_MESSAGE_SIZE))));
-        Host node2 = HostBuilder.build(TestPorts.getPort(), List.of(new Ping(), new Bitswap(new BitswapEngine(new RamBlockstore(), (c, b, p, a) -> CompletableFuture.completedFuture(true), Bitswap.MAX_MESSAGE_SIZE))));
+        Host node1 = HostBuilder.build(TestPorts.getPort(), List.of(new Ping(), new Bitswap(new BitswapEngine(new RamBlockstore(), (c, p, a) -> CompletableFuture.completedFuture(true), Bitswap.MAX_MESSAGE_SIZE))));
+        Host node2 = HostBuilder.build(TestPorts.getPort(), List.of(new Ping(), new Bitswap(new BitswapEngine(new RamBlockstore(), (c, p, a) -> CompletableFuture.completedFuture(true), Bitswap.MAX_MESSAGE_SIZE))));
         node1.start().join();
         IdentifyBuilder.addIdentifyProtocol(node1);
         node2.start().join();

--- a/src/test/java/org/peergos/ProvideTest.java
+++ b/src/test/java/org/peergos/ProvideTest.java
@@ -20,7 +20,7 @@ public class ProvideTest {
     public void provideBlock() {
         RamBlockstore blockstore = new RamBlockstore();
         HostBuilder builder1 = HostBuilder.create(TestPorts.getPort(),
-                new RamProviderStore(1000), new RamRecordStore(), blockstore, (c, b, p, a) -> CompletableFuture.completedFuture(true));
+                new RamProviderStore(1000), new RamRecordStore(), blockstore, (c, p, a) -> CompletableFuture.completedFuture(true));
         Host node1 = builder1.build();
         node1.start().join();
         Multihash node1Id = Multihash.deserialize(node1.getPeerId().getBytes());

--- a/src/test/java/org/peergos/RelayTest.java
+++ b/src/test/java/org/peergos/RelayTest.java
@@ -19,11 +19,11 @@ public class RelayTest {
     @Ignore // needs fixed find providers
     public void relay() {
         HostBuilder builder1 = HostBuilder.create(10000 + new Random().nextInt(50000),
-                new RamProviderStore(1000), new RamRecordStore(), new RamBlockstore(), (c, b, p, a) -> CompletableFuture.completedFuture(true));
+                new RamProviderStore(1000), new RamRecordStore(), new RamBlockstore(), (c, p, a) -> CompletableFuture.completedFuture(true));
         Host node1 = builder1.build();
         node1.start().join();
         HostBuilder builder2 = HostBuilder.create(10000 + new Random().nextInt(50000),
-                new RamProviderStore(1000), new RamRecordStore(), new RamBlockstore(), (c, b, p, a) -> CompletableFuture.completedFuture(true));
+                new RamProviderStore(1000), new RamRecordStore(), new RamBlockstore(), (c, p, a) -> CompletableFuture.completedFuture(true));
         Host node2 = builder2.build();
         node2.start().join();
 


### PR DESCRIPTION
This removes an attack where remote peers could DOS us with 1000s of requests for a block we have, but with invalid auth, each resulting in a block get from the blockstore. This is possible now because of the block metadata db.