### PR TITLE
use alternate method to list network interfaces

### DIFF
--- a/src/main/java/org/peergos/protocol/IdentifyBuilder.java
+++ b/src/main/java/org/peergos/protocol/IdentifyBuilder.java
@@ -60,7 +60,7 @@ public class IdentifyBuilder {
 
     public static List<Multiaddr> listNetworkAddresses(boolean includeIp6, Multiaddr addr) {
         try {
-            return NetworkInterface.networkInterfaces()
+            return Collections.list(NetworkInterface.getNetworkInterfaces()).stream()
                     .flatMap(net -> net.getInterfaceAddresses().stream()
                             .map(InterfaceAddress::getAddress)
                             .filter(ip -> includeIp6 || ip instanceof Inet4Address))


### PR DESCRIPTION
networkInterfaces() is available in Java9. Android tops out at java8 compatibility