### PR TITLE
Don't add incoming kademlia peers to routing table!

### DIFF
--- a/src/main/java/org/peergos/protocol/dht/Kademlia.java
+++ b/src/main/java/org/peergos/protocol/dht/Kademlia.java
@@ -26,12 +26,14 @@ public class Kademlia extends StrictProtocolBinding<KademliaController> implemen
 
     private static final Logger LOG = Logging.LOG();
     public static final int BOOTSTRAP_PERIOD_MILLIS = 300_000;
+    public static final String WAN_DHT_ID = "/ipfs/kad/1.0.0";
+    public static final String LAN_DHT_ID = "/ipfs/lan/kad/1.0.0";
     private final KademliaEngine engine;
     private final boolean localDht;
     private AddressBook addressBook;
 
     public Kademlia(KademliaEngine dht, boolean localOnly) {
-        super("/ipfs/" + (localOnly ? "lan/" : "") + "kad/1.0.0", new KademliaProtocol(dht));
+        super(localOnly ? LAN_DHT_ID : WAN_DHT_ID, new KademliaProtocol(dht));
         this.engine = dht;
         this.localDht = localOnly;
     }

--- a/src/main/java/org/peergos/protocol/dht/KademliaEngine.java
+++ b/src/main/java/org/peergos/protocol/dht/KademliaEngine.java
@@ -61,10 +61,14 @@ public class KademliaEngine {
     }
 
     public synchronized void addOutgoingConnection(PeerId peer) {
-        router.touch(Instant.now(), new Node(Id.create(Hash.sha256(peer.getBytes()), 256), peer.toString()));
+        addToRoutingTable(peer);
     }
 
     public synchronized void addIncomingConnection(PeerId peer) {
+        // don't auto add incoming kademlia connections to routing table
+    }
+
+    private void addToRoutingTable(PeerId peer) {
         router.touch(Instant.now(), new Node(Id.create(Hash.sha256(peer.getBytes()), 256), peer.toString()));
     }
 


### PR DESCRIPTION
Only add them if they announce kademlia (in Identify) and they answer a kademlia query on a new stream.