### PR TITLE
Optimise IPNS publishing and resolution

### DIFF
--- a/src/main/java/org/peergos/EmbeddedIpfs.java
+++ b/src/main/java/org/peergos/EmbeddedIpfs.java
@@ -23,6 +23,7 @@ import org.peergos.protocol.bitswap.*;
 import org.peergos.protocol.circuit.*;
 import org.peergos.protocol.dht.*;
 import org.peergos.protocol.http.*;
+import org.peergos.protocol.ipns.*;
 import org.peergos.util.Logging;
 
 import java.nio.file.*;
@@ -110,9 +111,9 @@ public class EmbeddedIpfs {
 
     public CompletableFuture<byte[]> resolveValue(PubKey pub) {
         Multihash publisher = Multihash.deserialize(PeerId.fromPubKey(pub).getBytes());
-        CompletableFuture<byte[]> res = new CompletableFuture<>();
-        dht.resolveValue(publisher, node, Kademlia.getNRecords(2, res));
-        return res;
+        List<IpnsRecord> candidates = dht.resolveValue(publisher, 1, node);
+        List<IpnsRecord> records = candidates.stream().sorted().collect(Collectors.toList());
+        return CompletableFuture.completedFuture(records.get(records.size() - 1).value);
     }
 
     public void start() {

--- a/src/main/java/org/peergos/EmbeddedIpfs.java
+++ b/src/main/java/org/peergos/EmbeddedIpfs.java
@@ -105,7 +105,12 @@ public class EmbeddedIpfs {
         Multihash pub = Multihash.deserialize(PeerId.fromPubKey(priv.publicKey()).getBytes());
         LocalDateTime expiry = LocalDateTime.now().plusHours(hoursTtl);
         long ttlNanos = hoursTtl * 3600_000_000_000L;
-        return dht.publishValue(priv, pub, value, sequence, expiry, ttlNanos, node);
+        byte[] signedRecord = IPNS.createSignedRecord(value, expiry, sequence, ttlNanos, priv);
+        return dht.publishValue(pub, signedRecord, node);
+    }
+
+    public CompletableFuture<Void> publishPresignedRecord(Multihash pub, byte[] presignedRecord) {
+        return dht.publishValue(pub, presignedRecord, node);
     }
 
     public CompletableFuture<byte[]> resolveValue(PubKey pub) {

--- a/src/main/java/org/peergos/EmbeddedIpfs.java
+++ b/src/main/java/org/peergos/EmbeddedIpfs.java
@@ -101,11 +101,10 @@ public class EmbeddedIpfs {
                 .collect(Collectors.toList());
     }
 
-    public CompletableFuture<Void> publishValue(PrivKey priv, byte[] value, long sequence) {
+    public CompletableFuture<Void> publishValue(PrivKey priv, byte[] value, long sequence, int hoursTtl) {
         Multihash pub = Multihash.deserialize(PeerId.fromPubKey(priv.publicKey()).getBytes());
-        int hours = 1;
-        LocalDateTime expiry = LocalDateTime.now().plusHours(hours);
-        long ttlNanos = hours * 3600_000_000_000L;
+        LocalDateTime expiry = LocalDateTime.now().plusHours(hoursTtl);
+        long ttlNanos = hoursTtl * 3600_000_000_000L;
         return dht.publishValue(priv, pub, value, sequence, expiry, ttlNanos, node);
     }
 

--- a/src/main/java/org/peergos/EmbeddedIpfs.java
+++ b/src/main/java/org/peergos/EmbeddedIpfs.java
@@ -113,9 +113,9 @@ public class EmbeddedIpfs {
         return dht.publishValue(pub, presignedRecord, node);
     }
 
-    public CompletableFuture<byte[]> resolveValue(PubKey pub) {
+    public CompletableFuture<byte[]> resolveValue(PubKey pub, int minResults) {
         Multihash publisher = Multihash.deserialize(PeerId.fromPubKey(pub).getBytes());
-        List<IpnsRecord> candidates = dht.resolveValue(publisher, 1, node);
+        List<IpnsRecord> candidates = dht.resolveValue(publisher, minResults, node);
         List<IpnsRecord> records = candidates.stream().sorted().collect(Collectors.toList());
         if (records.isEmpty())
             return CompletableFuture.failedFuture(new IllegalStateException("Couldn't resolve IPNS value for " + pub));

--- a/src/main/java/org/peergos/EmbeddedIpfs.java
+++ b/src/main/java/org/peergos/EmbeddedIpfs.java
@@ -113,6 +113,8 @@ public class EmbeddedIpfs {
         Multihash publisher = Multihash.deserialize(PeerId.fromPubKey(pub).getBytes());
         List<IpnsRecord> candidates = dht.resolveValue(publisher, 1, node);
         List<IpnsRecord> records = candidates.stream().sorted().collect(Collectors.toList());
+        if (records.isEmpty())
+            return CompletableFuture.failedFuture(new IllegalStateException("Couldn't resolve IPNS value for " + pub));
         return CompletableFuture.completedFuture(records.get(records.size() - 1).value);
     }
 

--- a/src/main/java/org/peergos/protocol/dht/DatabaseRecordStore.java
+++ b/src/main/java/org/peergos/protocol/dht/DatabaseRecordStore.java
@@ -61,7 +61,7 @@ public class DatabaseRecordStore implements RecordStore {
     }
 
     @Override
-    public Optional<IpnsRecord> get(Cid peerId) {
+    public Optional<IpnsRecord> get(Multihash peerId) {
         String selectSQL = "SELECT raw, sequence, ttlNanos, expiryUTC, val FROM " + RECORD_TABLE + " WHERE peerId=?";
         try (PreparedStatement pstmt = connection.prepareStatement(selectSQL)) {
             pstmt.setString(1, hashToKey(peerId));

--- a/src/main/java/org/peergos/protocol/dht/DatabaseRecordStore.java
+++ b/src/main/java/org/peergos/protocol/dht/DatabaseRecordStore.java
@@ -10,7 +10,7 @@ import java.io.InputStream;
 import java.sql.*;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import java.util.Optional;
+import java.util.*;
 
 public class DatabaseRecordStore implements RecordStore {
 
@@ -76,7 +76,7 @@ public class DatabaseRecordStore implements RecordStore {
                         LocalDateTime expiry = LocalDateTime.ofEpochSecond(rs.getLong("expiryUTC"),
                                 0, ZoneOffset.UTC);
                         IpnsRecord record = new IpnsRecord(bout.toByteArray(), rs.getLong("sequence"),
-                                rs.getLong("ttlNanos"),  expiry, rs.getString("val"));
+                                rs.getLong("ttlNanos"),  expiry, rs.getString("val").getBytes());
                         return Optional.of(record);
                     } catch (IOException readEx) {
                         throw new IllegalStateException(readEx);
@@ -102,8 +102,8 @@ public class DatabaseRecordStore implements RecordStore {
             pstmt.setLong(3, record.sequence);
             pstmt.setLong(4, record.ttlNanos);
             pstmt.setLong(5, record.expiry.toEpochSecond(ZoneOffset.UTC));
-            pstmt.setString(6, record.value.length() > SIZE_OF_VAL ?
-                    record.value.substring(0, SIZE_OF_VAL) : record.value);
+            pstmt.setString(6, new String(record.value.length > SIZE_OF_VAL ?
+                    Arrays.copyOfRange(record.value, 0, SIZE_OF_VAL) : record.value));
             pstmt.executeUpdate();
         } catch (SQLException ex) {
             throw new IllegalStateException(ex);

--- a/src/main/java/org/peergos/protocol/dht/Kademlia.java
+++ b/src/main/java/org/peergos/protocol/dht/Kademlia.java
@@ -432,6 +432,9 @@ public class Kademlia extends StrictProtocolBinding<KademliaController> implemen
     public List<IpnsRecord> resolveValue(Multihash publisher, int minResults, Host us) {
         byte[] key = IPNS.getKey(publisher);
         List<IpnsRecord> candidates = new ArrayList<>();
+        Optional<IpnsRecord> local = engine.getRecord(publisher);
+        local.ifPresent(candidates::add);
+
         Id keyId = Id.create(Hash.sha256(key), 256);
         SortedSet<RoutingEntry> toQuery = Collections.synchronizedSortedSet(new TreeSet<>((a, b) -> compareKeys(a, b, keyId)));
         List<PeerAddresses> localClosest = engine.getKClosestPeers(key);

--- a/src/main/java/org/peergos/protocol/dht/Kademlia.java
+++ b/src/main/java/org/peergos/protocol/dht/Kademlia.java
@@ -388,7 +388,7 @@ public class Kademlia extends StrictProtocolBinding<KademliaController> implemen
             if (toQuery.size() == remaining) {
                 // publish to closest remaining nodes
                 while (publishes.size() < minPublishes) {
-                    List<RoutingEntry> closest = toQuery.stream()
+                    List<RoutingEntry> closest = new TreeSet<>(toQuery).stream()
                     .limit(minPublishes - publishes.size() + 5)
                     .collect(Collectors.toList());
                     List<? extends Future<?>> lastFutures = closest.stream()

--- a/src/main/java/org/peergos/protocol/dht/KademliaController.java
+++ b/src/main/java/org/peergos/protocol/dht/KademliaController.java
@@ -20,10 +20,10 @@ public interface KademliaController {
 
     CompletableFuture<Boolean> send(Dht.Message msg);
 
-    default CompletableFuture<List<PeerAddresses>> closerPeers(Multihash peerID) {
+    default CompletableFuture<List<PeerAddresses>> closerPeers(byte[] key) {
         return rpc(Dht.Message.newBuilder()
                 .setType(Dht.Message.MessageType.FIND_NODE)
-                .setKey(ByteString.copyFrom(peerID.toBytes()))
+                .setKey(ByteString.copyFrom(key))
                 .build())
                 .thenApply(resp -> resp.getCloserPeersList().stream()
                         .map(PeerAddresses::fromProtobuf)

--- a/src/main/java/org/peergos/protocol/dht/KademliaController.java
+++ b/src/main/java/org/peergos/protocol/dht/KademliaController.java
@@ -47,9 +47,9 @@ public interface KademliaController {
                 .thenApply(Providers::fromProtobuf);
     }
 
-    default CompletableFuture<Boolean> putValue(String pathToPublish, LocalDateTime expiry, long sequence,
+    default CompletableFuture<Boolean> putValue(byte[] value, LocalDateTime expiry, long sequence,
                                                 long ttlNanos, Multihash peerId, PrivKey ourKey) {
-        byte[] cborEntryData = IPNS.createCborDataForIpnsEntry(pathToPublish, expiry,
+        byte[] cborEntryData = IPNS.createCborDataForIpnsEntry(value, expiry,
                 Ipns.IpnsEntry.ValidityType.EOL_VALUE, sequence, ttlNanos);
         String expiryString = IPNS.formatExpiry(expiry);
         byte[] signature = ourKey.sign(IPNS.createSigV2Data(cborEntryData));
@@ -62,7 +62,7 @@ public interface KademliaController {
         byte[] ipnsEntry = Ipns.IpnsEntry.newBuilder()
                 .setSequence(sequence)
                 .setTtl(ttlNanos)
-                .setValue(ByteString.copyFrom(pathToPublish.getBytes()))
+                .setValue(ByteString.copyFrom(value))
                 .setValidityType(Ipns.IpnsEntry.ValidityType.EOL)
                 .setValidity(ByteString.copyFrom(expiryString.getBytes()))
                 .setData(ByteString.copyFrom(cborEntryData))

--- a/src/main/java/org/peergos/protocol/dht/RamRecordStore.java
+++ b/src/main/java/org/peergos/protocol/dht/RamRecordStore.java
@@ -1,6 +1,5 @@
 package org.peergos.protocol.dht;
 
-import io.ipfs.cid.*;
 import io.ipfs.multihash.*;
 import org.peergos.protocol.ipns.*;
 
@@ -19,7 +18,7 @@ public class RamRecordStore implements RecordStore {
     }
 
     @Override
-    public Optional<IpnsRecord> get(Cid peerId) {
+    public Optional<IpnsRecord> get(Multihash peerId) {
         return Optional.ofNullable(records.get(peerId));
     }
 

--- a/src/main/java/org/peergos/protocol/dht/RecordStore.java
+++ b/src/main/java/org/peergos/protocol/dht/RecordStore.java
@@ -10,7 +10,7 @@ public interface RecordStore extends AutoCloseable {
 
     void put(Multihash peerId, IpnsRecord record);
 
-    Optional<IpnsRecord> get(Cid peerId);
+    Optional<IpnsRecord> get(Multihash peerId);
 
     void remove(Multihash peerId);
 }

--- a/src/main/java/org/peergos/protocol/ipns/GetResult.java
+++ b/src/main/java/org/peergos/protocol/ipns/GetResult.java
@@ -20,7 +20,7 @@ public class GetResult {
                 .map(PeerAddresses::fromProtobuf)
                 .collect(Collectors.toList());
         Optional<IpnsMapping> record = msg.hasRecord() ?
-                IPNS.validateIpnsEntry(msg) :
+                IPNS.parseAndValidateIpnsEntry(msg) :
                 Optional.empty();
         return new GetResult(record, closerPeers);
     }

--- a/src/main/java/org/peergos/protocol/ipns/IPNS.java
+++ b/src/main/java/org/peergos/protocol/ipns/IPNS.java
@@ -40,14 +40,14 @@ public class IPNS {
         return Cid.cast(key.substring(6).toByteArray());
     }
 
-    public static byte[] createCborDataForIpnsEntry(String pathToPublish,
+    public static byte[] createCborDataForIpnsEntry(byte[] value,
                                                     LocalDateTime expiry,
                                                     long validityType,
                                                     long sequence,
                                                     long ttl) {
         SortedMap<String, Cborable> state = new TreeMap<>();
         state.put("TTL", new CborObject.CborLong(ttl));
-        state.put("Value", new CborObject.CborByteArray(pathToPublish.getBytes()));
+        state.put("Value", new CborObject.CborByteArray(value));
         state.put("Sequence", new CborObject.CborLong(sequence));
         String expiryString = formatExpiry(expiry);
         state.put("Validity", new CborObject.CborByteArray(expiryString.getBytes(StandardCharsets.UTF_8)));
@@ -109,7 +109,7 @@ public class IPNS {
             if (expiry.isBefore(LocalDateTime.now()))
                 return Optional.empty();
             byte[] entryBytes = msg.getRecord().getValue().toByteArray();
-            IpnsRecord record = new IpnsRecord(entryBytes, entry.getSequence(), entry.getTtl(), expiry, entry.getValue().toStringUtf8());
+            IpnsRecord record = new IpnsRecord(entryBytes, entry.getSequence(), entry.getTtl(), expiry, entry.getValue().toByteArray());
             return Optional.of(new IpnsMapping(signer, record));
         } catch (InvalidProtocolBufferException e) {
             return Optional.empty();

--- a/src/main/java/org/peergos/protocol/ipns/IpnsRecord.java
+++ b/src/main/java/org/peergos/protocol/ipns/IpnsRecord.java
@@ -9,9 +9,9 @@ public class IpnsRecord implements Comparable<IpnsRecord> {
     public final byte[] raw;
     public final long sequence, ttlNanos;
     public final LocalDateTime expiry;
-    public final String value;
+    public final byte[] value;
 
-    public IpnsRecord(byte[] raw, long sequence, long ttlNanos, LocalDateTime expiry, String value) {
+    public IpnsRecord(byte[] raw, long sequence, long ttlNanos, LocalDateTime expiry, byte[] value) {
         this.raw = raw;
         this.sequence = sequence;
         this.ttlNanos = ttlNanos;

--- a/src/test/java/org/peergos/DatabaseRecordStoreTest.java
+++ b/src/test/java/org/peergos/DatabaseRecordStoreTest.java
@@ -13,7 +13,7 @@ public class DatabaseRecordStoreTest {
     public void testRecordStore() {
         try (DatabaseRecordStore bs = new DatabaseRecordStore("mem:")) {
             LocalDateTime now = LocalDateTime.now();
-            IpnsRecord record = new IpnsRecord("raw".getBytes(), 1, 2, now, "value");
+            IpnsRecord record = new IpnsRecord("raw".getBytes(), 1, 2, now, "value".getBytes());
             Cid peerId = Cid.decode("zb2rhYSxw4ZjuzgCnWSt19Q94ERaeFhu9uSqRgjSdx9bsgM6f");
             bs.put(peerId, record);
             //make sure PUTing a second time succeeds

--- a/src/test/java/org/peergos/EmbeddedIpfsTest.java
+++ b/src/test/java/org/peergos/EmbeddedIpfsTest.java
@@ -86,6 +86,16 @@ public class EmbeddedIpfsTest {
         byte[] res2 = node1.resolveValue(publisher.publicKey()).join();
         Assert.assertTrue(Arrays.equals(res2, value2));
 
+        // publish an updated value with earlier expiry
+        byte[] value3 = "3rd value to put in IPNS".getBytes();
+        byte[] signedRecord3 = IPNS.createSignedRecord(value3, expiry.minusDays(1), 3, ttlNanos, publisher);
+        node1.publishPresignedRecord(pub, signedRecord3).join();
+        node1.publishPresignedRecord(pub, signedRecord3).join();
+        node1.publishPresignedRecord(pub, signedRecord3).join();
+
+        byte[] res3 = node1.resolveValue(publisher.publicKey()).join();
+        Assert.assertTrue(Arrays.equals(res3, value3));
+
         node1.stop();
     }
 

--- a/src/test/java/org/peergos/EmbeddedIpfsTest.java
+++ b/src/test/java/org/peergos/EmbeddedIpfsTest.java
@@ -47,7 +47,7 @@ public class EmbeddedIpfsTest {
 
         PrivKey publisher = Ed25519Kt.generateEd25519KeyPair().getFirst();
         byte[] value = "This is a test".getBytes();
-        node1.publishValue(publisher, value, 1).join();
+        node1.publishValue(publisher, value, 1, 24).join();
         byte[] res = node1.resolveValue(publisher.publicKey()).join();
         Assert.assertTrue(Arrays.equals(res, value));
 

--- a/src/test/java/org/peergos/EmbeddedIpfsTest.java
+++ b/src/test/java/org/peergos/EmbeddedIpfsTest.java
@@ -6,6 +6,7 @@ import io.ipfs.multiaddr.*;
 import io.libp2p.core.*;
 import io.libp2p.core.crypto.*;
 import io.libp2p.core.multiformats.*;
+import io.libp2p.crypto.keys.*;
 import io.libp2p.protocol.*;
 import org.junit.*;
 import org.peergos.blockstore.*;
@@ -37,6 +38,20 @@ public class EmbeddedIpfsTest {
 
         node1.stop();
         node2.stop();
+    }
+
+    @Test
+    public void publishValue() throws Exception {
+        EmbeddedIpfs node1 = build(BootstrapTest.BOOTSTRAP_NODES, List.of(new MultiAddress("/ip4/127.0.0.1/tcp/" + TestPorts.getPort())));
+        node1.start();
+
+        PrivKey publisher = Ed25519Kt.generateEd25519KeyPair().getFirst();
+        byte[] value = "This is a test".getBytes();
+        node1.publishValue(publisher, value, 1).join();
+        byte[] res = node1.resolveValue(publisher.publicKey()).join();
+        Assert.assertTrue(Arrays.equals(res, value));
+
+        node1.stop();
     }
 
     @Test

--- a/src/test/java/org/peergos/EmbeddedIpfsTest.java
+++ b/src/test/java/org/peergos/EmbeddedIpfsTest.java
@@ -51,7 +51,7 @@ public class EmbeddedIpfsTest {
         PrivKey publisher = Ed25519Kt.generateEd25519KeyPair().getFirst();
         byte[] value = "This is a test".getBytes();
         node1.publishValue(publisher, value, 1, 24).join();
-        byte[] res = node1.resolveValue(publisher.publicKey()).join();
+        byte[] res = node1.resolveValue(publisher.publicKey(), 5).join();
         Assert.assertTrue(Arrays.equals(res, value));
 
         node1.stop();
@@ -73,7 +73,7 @@ public class EmbeddedIpfsTest {
         node1.publishPresignedRecord(pub, signedRecord).join();
         node1.publishPresignedRecord(pub, signedRecord).join();
 
-        byte[] res = node1.resolveValue(publisher.publicKey()).join();
+        byte[] res = node1.resolveValue(publisher.publicKey(), 5).join();
         Assert.assertTrue(Arrays.equals(res, value));
 
         // publish an updated value with same expiry
@@ -83,7 +83,7 @@ public class EmbeddedIpfsTest {
         node1.publishPresignedRecord(pub, signedRecord2).join();
         node1.publishPresignedRecord(pub, signedRecord2).join();
 
-        byte[] res2 = node1.resolveValue(publisher.publicKey()).join();
+        byte[] res2 = node1.resolveValue(publisher.publicKey(), 5).join();
         Assert.assertTrue(Arrays.equals(res2, value2));
 
         // publish an updated value with earlier expiry
@@ -93,7 +93,7 @@ public class EmbeddedIpfsTest {
         node1.publishPresignedRecord(pub, signedRecord3).join();
         node1.publishPresignedRecord(pub, signedRecord3).join();
 
-        byte[] res3 = node1.resolveValue(publisher.publicKey()).join();
+        byte[] res3 = node1.resolveValue(publisher.publicKey(), 5).join();
         Assert.assertTrue(Arrays.equals(res3, value3));
 
         node1.stop();

--- a/src/test/java/org/peergos/EmbeddedIpfsTest.java
+++ b/src/test/java/org/peergos/EmbeddedIpfsTest.java
@@ -65,7 +65,7 @@ public class EmbeddedIpfsTest {
         PrivKey publisher = Ed25519Kt.generateEd25519KeyPair().getFirst();
         byte[] value = "This is a test".getBytes();
         io.ipfs.multihash.Multihash pub = Multihash.deserialize(PeerId.fromPubKey(publisher.publicKey()).getBytes());
-        long hoursTtl = 24*2;
+        long hoursTtl = 24*365;
         LocalDateTime expiry = LocalDateTime.now().plusHours(hoursTtl);
         long ttlNanos = hoursTtl * 3600_000_000_000L;
         byte[] signedRecord = IPNS.createSignedRecord(value, expiry, 1, ttlNanos, publisher);
@@ -75,6 +75,16 @@ public class EmbeddedIpfsTest {
 
         byte[] res = node1.resolveValue(publisher.publicKey()).join();
         Assert.assertTrue(Arrays.equals(res, value));
+
+        // publish an updated value with same expiry
+        byte[] value2 = "Updated value".getBytes();
+        byte[] signedRecord2 = IPNS.createSignedRecord(value2, expiry, 2, ttlNanos, publisher);
+        node1.publishPresignedRecord(pub, signedRecord2).join();
+        node1.publishPresignedRecord(pub, signedRecord2).join();
+        node1.publishPresignedRecord(pub, signedRecord2).join();
+
+        byte[] res2 = node1.resolveValue(publisher.publicKey()).join();
+        Assert.assertTrue(Arrays.equals(res2, value2));
 
         node1.stop();
     }

--- a/src/test/java/org/peergos/FindPeerTest.java
+++ b/src/test/java/org/peergos/FindPeerTest.java
@@ -49,7 +49,7 @@ public class FindPeerTest {
         PeerAddresses peer = matching.get();
         Multiaddr[] addrs = peer.getPublicAddresses().stream().map(a -> Multiaddr.fromString(a.toString())).toArray(Multiaddr[]::new);
         dht1.dial(node1, PeerId.fromBase58(peer.peerId.toBase58()), addrs)
-                .getController().join().closerPeers(toFind).join();
+                .getController().join().closerPeers(toFind.toBytes()).join();
         System.out.println("Peer lookup took " + (t2-t1) + "ms");
         return t2 - t1;
     }

--- a/src/test/java/org/peergos/IpnsTest.java
+++ b/src/test/java/org/peergos/IpnsTest.java
@@ -49,7 +49,7 @@ public class IpnsTest {
             for (int i = 0; i < 10; i++) {
                 try {
                     success = dht.dial(node1, address2).getController().join()
-                            .putValue(pathToPublish, expiry, sequence, ttl, node1Id, node1.getPrivKey())
+                            .putValue(pathToPublish.getBytes(), expiry, sequence, ttl, node1Id, node1.getPrivKey())
                             .orTimeout(2, TimeUnit.SECONDS).join();
                     break;
                 } catch (Exception timeout) {

--- a/src/test/java/org/peergos/IpnsTest.java
+++ b/src/test/java/org/peergos/IpnsTest.java
@@ -2,7 +2,6 @@ package org.peergos;
 
 import io.ipfs.api.*;
 import io.ipfs.cid.*;
-import io.ipfs.multiaddr.*;
 import io.ipfs.multihash.Multihash;
 import io.libp2p.core.*;
 import io.libp2p.core.multiformats.*;
@@ -48,8 +47,9 @@ public class IpnsTest {
 
             for (int i = 0; i < 10; i++) {
                 try {
+                    byte[] value = IPNS.createSignedRecord(pathToPublish.getBytes(), expiry, sequence, ttl, node1.getPrivKey());
                     success = dht.dial(node1, address2).getController().join()
-                            .putValue(pathToPublish.getBytes(), expiry, sequence, ttl, node1Id, node1.getPrivKey())
+                            .putValue(node1Id, value)
                             .orTimeout(2, TimeUnit.SECONDS).join();
                     break;
                 } catch (Exception timeout) {

--- a/src/test/java/org/peergos/KademliaTest.java
+++ b/src/test/java/org/peergos/KademliaTest.java
@@ -87,7 +87,7 @@ public class KademliaTest {
 
             List<PrivKey> signers = new ArrayList<>();
             long publishTotal = 0, resolveTotal = 0;
-            int iterations = 5;
+            int iterations = 25;
             for (int i = 0; i < iterations; i++) {
                 // publish mapping from node 1
                 PrivKey signer = Ed25519Kt.generateEd25519KeyPair().getFirst();

--- a/src/test/java/org/peergos/KademliaTest.java
+++ b/src/test/java/org/peergos/KademliaTest.java
@@ -96,7 +96,7 @@ public class KademliaTest {
                 long p0 = System.currentTimeMillis();
                 dht1.publishIpnsValue(signer, pub, value, 1, node1).join();
                 long p1 = System.currentTimeMillis();
-                System.out.println("Publish took " + (p1-p0) + "ms");
+                System.out.println("Publish took " + printSeconds(p1-p0) + "s");
                 publishTotal += p1-p0;
 
                 // retrieve it from node 2
@@ -104,7 +104,7 @@ public class KademliaTest {
                 String res = dht2.resolveIpnsValue(pub, node2, 1).orTimeout(10, TimeUnit.SECONDS).join();
                 long t1 = System.currentTimeMillis();
                 Assert.assertTrue(res.equals("/ipfs/" + value));
-                System.out.println("Resolved in " + (t1 - t0) + "ms");
+                System.out.println("Resolved in " + printSeconds(t1 - t0) + "s");
                 resolveTotal += t1-t0;
             }
             System.out.println("Publish av: " + publishTotal/iterations + ", resolve av: " + resolveTotal/iterations);
@@ -116,12 +116,16 @@ public class KademliaTest {
                 String res = dht2.resolveIpnsValue(pub, node2, 1).orTimeout(10, TimeUnit.SECONDS).join();
                 long t1 = System.currentTimeMillis();
                 Assert.assertTrue(res.equals("/ipfs/" + value));
-                System.out.println("Resolved again in " + (t1 - t0) + "ms");
+                System.out.println("Resolved again in " + printSeconds(t1 - t0) + "s");
             }
         } finally {
             node1.stop();
             node2.stop();
         }
+    }
+
+    public static String printSeconds(long millis) {
+        return millis / 1000 + "." + (millis % 1000)/100;
     }
 
     @Test

--- a/src/test/java/org/peergos/KademliaTest.java
+++ b/src/test/java/org/peergos/KademliaTest.java
@@ -87,7 +87,7 @@ public class KademliaTest {
 
             List<PrivKey> signers = new ArrayList<>();
             long publishTotal = 0, resolveTotal = 0;
-            int iterations = 10;
+            int iterations = 5;
             for (int i = 0; i < iterations; i++) {
                 // publish mapping from node 1
                 PrivKey signer = Ed25519Kt.generateEd25519KeyPair().getFirst();


### PR DESCRIPTION
This brings publish times down to ~4-14s and resolution times to mostly ~0.5-3s

We also add an api to EmbeddedIpfs for this, includikng publishing presigned records.